### PR TITLE
Use the pre-built Docker image and cfdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is part of [cloud.gov](https://cloud.gov/), deployment pipeline for [Strato
 ## Customizing the frontend
 
 ### Get dependencies
-* Install [NodeJs](https://nodejs.org) - `brew install node`
+* Install [NodeJs v10](https://nodejs.org) - `brew install node@10; brew unlink node; brew link --verwrite --force node@10`
 * Install [Angular CLI](https://cli.angular.io/) - `brew install angular-cli`
 * Install [Docker](https://www.docker.com/) - `brew cask install docker`
 * Clone this repository

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is part of [cloud.gov](https://cloud.gov/), deployment pipeline for [Strato
 ## Customizing the frontend
 
 ### Get dependencies
-* Install [NodeJs v10](https://nodejs.org) - `brew install node@10; brew unlink node; brew link --verwrite --force node@10`
+* Install [NodeJs v10](https://nodejs.org) - `brew install node@10; brew unlink node; brew link --overwrite --force node@10`
 * Install [Angular CLI](https://cli.angular.io/) - `brew install angular-cli`
 * Install [Docker](https://www.docker.com/) - `brew cask install docker`
 * Clone this repository


### PR DESCRIPTION
* Using the Docker image means removes some steps and results in less waiting around for assets to be prebuilt, at the cost of having Docker installed; seems like a reasonable tradeoff to ensure we're always able to run a stable ready-to-go version!
* Using `cfdev` as the CF target instead of cloud.gov takes (much) longer to start up but the benefit is that you can fully examine all of the functionality in Stratos.