### PR TITLE
allow trailing slash on redirect

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -63,7 +63,7 @@ jobs:
       environment_variables:
         SSO_LOGIN: "true"
         SSO_OPTIONS: "nosplash,logout"
-        SSO_WHITELIST: "https://((dev-cf-route))"
+        SSO_WHITELIST: "https://((dev-cf-route)),https://((dev-cf-route))/"
         CF_CLIENT: stratos
         CF_CLIENT_SECRET: ((dev-cf-client-secret))
         SESSION_STORE_SECRET: ((dev-session-store-secret))
@@ -112,7 +112,7 @@ jobs:
       environment_variables:
         SSO_LOGIN: "true"
         SSO_OPTIONS: "nosplash,logout"
-        SSO_WHITELIST: "https://((staging-cf-route))"
+        SSO_WHITELIST: "https://((staging-cf-route)),https://((staging-cf-route))/"
         CF_CLIENT: stratos
         CF_CLIENT_SECRET: ((staging-cf-client-secret))
         SESSION_STORE_SECRET: ((staging-session-store-secret))
@@ -172,7 +172,7 @@ jobs:
       environment_variables:
         SSO_LOGIN: "true"
         SSO_OPTIONS: "nosplash,logout"
-        SSO_WHITELIST: "https://((production-cf-route))"
+        SSO_WHITELIST: "https://((production-cf-route)),https://((production-cf-route))/"
         CF_CLIENT: stratos
         CF_CLIENT_SECRET: ((production-cf-client-secret))
         SESSION_STORE_SECRET: ((production-session-store-secret))


### PR DESCRIPTION
## Changes proposed in this pull request:
- fixes the sso whitelist. Browsing to stratos redirects users to dashboard.fr.cloud.gov/ (note trailing slash), so the redirect filter fails.

N.B. I already shipped this change, because stratos was completely unavailable without it

## security considerations
None