### PR TITLE
Add deprecated route for legacy dashboard

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -126,6 +126,7 @@ jobs:
       vars:
         external-route: dashboard-beta.fr-stage.cloud.gov
         app-route: dashboard-beta.apps.fr-stage.cloud.gov
+        deprecated-route: dashboard-deprecated.fr-stage.cloud.gov
         redirect-url: dashboard.fr-stage.cloud.gov
   on_failure:
     put: slack
@@ -186,6 +187,7 @@ jobs:
       vars:
         external-route: dashboard-beta.fr.cloud.gov
         app-route: dashboard-beta.app.cloud.gov
+        deprecated-route: dashboard-deprecated.fr.cloud.gov
         redirect-url: dashboard.fr.cloud.gov
   on_failure:
     put: slack

--- a/redirects/manifest.yml
+++ b/redirects/manifest.yml
@@ -8,6 +8,7 @@ applications:
   routes:
   - route: ((external-route))
   - route: ((app-route))
+  - route: ((deprecated-route))
   stack: cflinuxfs3
   env:
     REDIRECT_URL: ((redirect-url))


### PR DESCRIPTION
This PR adds redirects so the deprecated-dashboard route redirects users to the new, Stratos dashboard.

## Changes proposed in this pull request:
- Add redirects for legacy dashboard to point to the current dashboard

## security considerations
N/A - we're just removing access to the legacy dashboard and redirecting users to the new, Stratos-based one.
