### PR TITLE
unset SSO_WHITELIST until we have a version that does not break stuff

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -63,7 +63,6 @@ jobs:
       environment_variables:
         SSO_LOGIN: "true"
         SSO_OPTIONS: "nosplash,logout"
-        SSO_WHITELIST: "https://((dev-cf-route))"
         CF_CLIENT: stratos
         CF_CLIENT_SECRET: ((dev-cf-client-secret))
         SESSION_STORE_SECRET: ((dev-session-store-secret))
@@ -112,7 +111,6 @@ jobs:
       environment_variables:
         SSO_LOGIN: "true"
         SSO_OPTIONS: "nosplash,logout"
-        SSO_WHITELIST: "https://((staging-cf-route))"
         CF_CLIENT: stratos
         CF_CLIENT_SECRET: ((staging-cf-client-secret))
         SESSION_STORE_SECRET: ((staging-session-store-secret))
@@ -173,7 +171,6 @@ jobs:
       environment_variables:
         SSO_LOGIN: "true"
         SSO_OPTIONS: "nosplash,logout"
-        SSO_WHITELIST: "https://((production-cf-route))"
         CF_CLIENT: stratos
         CF_CLIENT_SECRET: ((production-cf-client-secret))
         SESSION_STORE_SECRET: ((production-session-store-secret))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Unset SSO_WHITELIST, since it's overly-strict

## security considerations
None - this is bringing git up-to-date with production