### PR TITLE
the dummy globs param should be an array

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,7 +6,7 @@ jobs:
     - get: next-stratos-release
       trigger: true
       params:
-        globs: do-not-download-assets
+        globs: [do-not-download-assets]
     - put: slack
       params:
         text: |


### PR DESCRIPTION
## Changes proposed in this pull request:
The `new-major-upstream` job is erroring due to the github-release resource's `globs` parameter being a string rather than an array. This PR simply changes the parameter to an array type.

## security considerations
None because there are no changes to functionality. Just a syntax update.
