### PR TITLE
modified:   ci/pipeline.yml to allow Stratos to use the harden-concou…

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -24,10 +24,13 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: node
-              tag: 16
+              repository: harden-concourse-task
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              aws_region: us-gov-west-1
+              tag: ((harden-concourse-task-tag))
           inputs:
             - name: stratos-source
             - name: config
@@ -75,10 +78,13 @@ jobs:
             - name: compiled
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: golang
-              tag: 1.18.3-stretch
+              repository: harden-concourse-task
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              aws_region: us-gov-west-1
+              tag: ((harden-concourse-task-tag))
           run:
             path: /bin/sh
             args:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -146,6 +146,16 @@ jobs:
           plan: medium-psql
       - put: cf-dev
         params:
+          config:
+            platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: harden-concourse-task
+              aws_region: us-gov-west-1
+              tag: ((harden-concourse-task-tag))
           path: compiled
           current_app_name: stratos
           manifest: compiled/manifest.yml
@@ -197,6 +207,16 @@ jobs:
           <<: *db-params
       - put: cf-staging
         params:
+          config:
+            platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: harden-concourse-task
+              aws_region: us-gov-west-1
+              tag: ((harden-concourse-task-tag))
           path: compiled/
           current_app_name: stratos
           manifest: compiled/manifest.yml
@@ -214,6 +234,16 @@ jobs:
         # This can eventually be removed, once we're sure nobody is linking to
         # dashboard-beta.
         params:
+          config:
+            platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: harden-concourse-task
+              aws_region: us-gov-west-1
+              tag: ((harden-concourse-task-tag))
           path: config/redirects
           manifest: config/redirects/manifest.yml
           current_app_name: dashboard-beta-redirects
@@ -258,6 +288,16 @@ jobs:
           <<: *db-params
       - put: cf-production
         params:
+          config:
+            platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: harden-concourse-task
+              aws_region: us-gov-west-1
+              tag: ((harden-concourse-task-tag))
           path: compiled/
           current_app_name: stratos
           manifest: compiled/manifest.yml
@@ -275,6 +315,16 @@ jobs:
         # This can eventually be removed, once we're sure nobody is linking to
         # dashboard-beta.
         params:
+          config:
+            platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: harden-concourse-task
+              aws_region: us-gov-west-1
+              tag: ((harden-concourse-task-tag))
           path: config/redirects
           manifest: config/redirects/manifest.yml
           current_app_name: dashboard-beta-redirects

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -61,6 +61,16 @@ jobs:
       - put: pre-compiled
         params:
           file: pre-compiled/precompiled-stratos.tgz
+          config:
+            platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: harden-concourse-task
+              aws_region: us-gov-west-1
+              tag: ((harden-concourse-task-tag))
 
   - name: compile-stratos
     serial: true
@@ -102,6 +112,16 @@ jobs:
       - put: compiled
         params:
           file: compiled/compiled-stratos.tgz
+          config:
+            platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: harden-concourse-task
+              aws_region: us-gov-west-1
+              tag: ((harden-concourse-task-tag))
 
   - name: deploy-dev
     serial: true


### PR DESCRIPTION
…rse-task image

## Changes proposed in this pull request:
- modified:   ci/pipeline.yml to allow Stratos to use the harden-concourse-task image
-
-

## security considerations
This will allow us to use a hardened image for Stratos.