### PR TITLE
force interactive login shell so nvm injects npm

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -36,7 +36,7 @@ jobs:
           run:
             path: sh
             args:
-              - -exc
+              - -ilexc
               - |
                 cd stratos-source
 
@@ -283,7 +283,7 @@ resource_types:
     repository: registry-image-resource
     aws_region: us-gov-west-1
     tag: latest
-  
+
 - name: cf-cli-resource
   type: registry-image
   source:


### PR DESCRIPTION
## Changes proposed in this pull request:
- force interactive login shell so nvm injects npm. cloud-gov/general-task#168 switched npm to be installed with `nvm`, so it's now shimmed in via `.profile`. `sh -exc` doesn't load `.profile`


## security considerations
None 